### PR TITLE
Refine compact IM channel tabs

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2714,23 +2714,22 @@ var CSS3 = String.raw`
 .dim-title { display: flex; align-items: center; justify-content: space-between; gap: 22px; margin: 0 0 26px; }
 .dim-title p { margin: 0; color: var(--dsw-alias-label-secondary, #646a73); font-size: 13px; line-height: 20px; white-space: nowrap; }
 .dim-channelCount { flex: none; padding: 6px 11px; border-radius: 999px; color: var(--dsw-alias-label-secondary, #646a73); background: var(--dsw-alias-fill-secondary, #f2f3f5); font-size: 11px; white-space: nowrap; }
-.dim-layout { display: grid; grid-template-columns: 188px 1px minmax(0, 1fr); gap: 26px; align-items: start; }
-.dim-rail { display: grid; gap: 12px; }
-.dim-channel { width: 100%; min-height: 76px; display: grid; grid-template-columns: 42px minmax(0, 1fr) 14px; align-items: center; gap: 12px; padding: 13px 12px; border: 1px solid transparent; border-radius: 16px; color: inherit; background: var(--dsw-alias-bg-layer-3, #fff); box-shadow: 0 5px 18px rgb(31 35 41 / 5%); font: inherit; text-align: left; cursor: pointer; transition: border-color .16s ease, background .16s ease, box-shadow .16s ease, transform .16s ease; }
-.dim-channel:hover { transform: translateY(-1px); border-color: color-mix(in srgb, var(--dim-blue) 25%, transparent); box-shadow: 0 8px 24px rgb(31 35 41 / 8%); }
-.dim-channel[aria-selected="true"] { border-color: color-mix(in srgb, var(--dim-blue) 52%, transparent); color: var(--dim-blue); background: var(--dim-blue-soft); box-shadow: 0 0 0 1px color-mix(in srgb, var(--dim-blue) 8%, transparent), 0 10px 26px rgb(51 112 255 / 10%); }
-.dim-channel:focus-visible { outline: 2px solid color-mix(in srgb, var(--dim-blue) 68%, white); outline-offset: 2px; }
-.dim-logo { width: 42px; height: 42px; display: grid; place-items: center; border-radius: 12px; box-shadow: 0 1px 4px rgb(31 35 41 / 8%); }
-.dim-logo svg { display: block; width: 27px; height: 27px; }
+.dim-layout { display: grid; grid-template-columns: 174px 1px minmax(0, 1fr); gap: 24px; align-items: start; }
+.dim-rail { max-height: 520px; display: grid; align-content: start; gap: 8px; overflow-y: auto; padding: 1px 4px 1px 1px; scrollbar-width: thin; scrollbar-color: var(--dsw-alias-line-border, #dfe1e5) transparent; }
+.dim-rail::-webkit-scrollbar { width: 4px; }
+.dim-rail::-webkit-scrollbar-thumb { border-radius: 99px; background: var(--dsw-alias-line-border, #dfe1e5); }
+.dim-channel { width: 100%; min-height: 48px; display: grid; grid-template-columns: 30px minmax(0, 1fr); align-items: center; gap: 10px; padding: 8px 12px; border: 1px solid var(--dsw-alias-line-border, #eef0f3); border-radius: 14px; color: inherit; background: var(--dsw-alias-bg-layer-3, #fff); box-shadow: 0 2px 8px rgb(31 35 41 / 3%); font: inherit; text-align: left; cursor: pointer; transition: border-color .16s ease, background .16s ease, box-shadow .16s ease; }
+.dim-channel:hover { border-color: color-mix(in srgb, var(--dim-blue) 25%, var(--dsw-alias-line-border, #eef0f3)); background: color-mix(in srgb, var(--dim-blue) 2%, var(--dsw-alias-bg-layer-3, #fff)); box-shadow: 0 5px 16px rgb(31 35 41 / 5%); }
+.dim-channel[aria-selected="true"] { border-color: color-mix(in srgb, var(--dim-blue) 43%, white); color: var(--dim-blue); background: color-mix(in srgb, var(--dim-blue) 9%, white); box-shadow: 0 3px 12px rgb(51 112 255 / 7%); }
+.dim-channel:focus-visible { outline: none; border-color: color-mix(in srgb, var(--dim-blue) 72%, white); box-shadow: 0 0 0 1px color-mix(in srgb, var(--dim-blue) 24%, transparent) inset, 0 3px 12px rgb(51 112 255 / 7%); }
+.dim-logo { width: 30px; height: 30px; display: grid; place-items: center; border-radius: 9px; box-shadow: 0 1px 3px rgb(31 35 41 / 7%); }
+.dim-logo svg { display: block; width: 20px; height: 20px; }
 .dim-logoWeixin { color: white; background: #07c160; }
-.dim-logoWeixin svg { width: 25px; height: 25px; }
+.dim-logoWeixin svg { width: 19px; height: 19px; }
 .dim-logoFeishu { background: white; border: 1px solid var(--dsw-alias-line-border, #e5e6eb); }
-.dim-logoFeishu svg { width: 30px; height: 30px; }
-.dim-channelCopy { min-width: 0; display: grid; gap: 2px; }
-.dim-channelCopy strong { overflow: hidden; color: inherit; font-size: 15px; line-height: 21px; font-weight: 680; text-overflow: ellipsis; white-space: nowrap; }
-.dim-channelCopy small { overflow: hidden; color: var(--dsw-alias-label-tertiary, #8f959e); font-size: 10px; line-height: 16px; text-overflow: ellipsis; white-space: nowrap; }
-.dim-chevron { color: var(--dsw-alias-label-tertiary, #8f959e); font-size: 22px; line-height: 1; transform: translateY(-1px); }
-.dim-channel[aria-selected="true"] .dim-chevron { color: var(--dim-blue); }
+.dim-logoFeishu svg { width: 22px; height: 22px; }
+.dim-channelCopy { min-width: 0; display: block; }
+.dim-channelCopy strong { overflow: hidden; color: inherit; font-size: 14px; line-height: 20px; font-weight: 680; text-overflow: ellipsis; white-space: nowrap; }
 .dim-divider { width: 1px; min-height: 520px; background: var(--dsw-alias-line-divider, #eef0f3); }
 .dim-panel { min-width: 0; }
 .dim-panel .bxf-page, .dim-panel .dxw-page { width: 100%; max-width: none; padding: 0 0 24px; }
@@ -2741,7 +2740,8 @@ var CSS3 = String.raw`
   .dim-layout { grid-template-columns: minmax(0, 1fr); gap: 18px; }
   .dim-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .dim-divider { display: none; }
-  .dim-channel { min-height: 68px; }
+  .dim-rail { max-height: none; overflow: visible; padding-right: 1px; }
+  .dim-channel { min-height: 48px; }
 }
 @media (max-width: 560px) {
   .dim-title { flex-direction: column; gap: 10px; }
@@ -2771,8 +2771,8 @@ var h3 = React3.createElement;
 var name = "im-settings";
 var inject = ["slots", "connection"];
 var CHANNELS = Object.freeze([
-  { id: "weixin", label: "\u5FAE\u4FE1", description: "\u626B\u7801\u7ED1\u5B9A" },
-  { id: "feishu", label: "\u98DE\u4E66", description: "\u626B\u7801\u63A5\u5165" }
+  { id: "weixin", label: "\u5FAE\u4FE1" },
+  { id: "feishu", label: "\u98DE\u4E66" }
 ]);
 function WeixinLogo() {
   return h3(
@@ -2838,10 +2838,8 @@ function IMSettingsTab({ feishuRpcCall, weixinRpcCall }) {
           h3(
             "span",
             { className: "dim-channelCopy" },
-            h3("strong", null, channel.label),
-            h3("small", null, channel.description)
-          ),
-          h3("span", { className: "dim-chevron", "aria-hidden": "true" }, "\u203A")
+            h3("strong", null, channel.label)
+          )
         ))
       ),
       h3("div", { className: "dim-divider", "aria-hidden": "true" }),

--- a/plugin-src/client/index.js
+++ b/plugin-src/client/index.js
@@ -14,8 +14,8 @@ export const name = 'im-settings';
 export const inject = ['slots', 'connection'];
 
 const CHANNELS = Object.freeze([
-  { id: 'weixin', label: '微信', description: '扫码绑定' },
-  { id: 'feishu', label: '飞书', description: '扫码接入' },
+  { id: 'weixin', label: '微信' },
+  { id: 'feishu', label: '飞书' },
 ]);
 
 function WeixinLogo() {
@@ -64,9 +64,7 @@ export function IMSettingsTab({ feishuRpcCall, weixinRpcCall }) {
         h(ChannelLogo, { channel: channel.id }),
         h('span', { className: 'dim-channelCopy' },
           h('strong', null, channel.label),
-          h('small', null, channel.description),
-        ),
-        h('span', { className: 'dim-chevron', 'aria-hidden': 'true' }, '›')))),
+        )))),
       h('div', { className: 'dim-divider', 'aria-hidden': 'true' }),
       h('main', {
         className: 'dim-panel',

--- a/plugin-src/client/styles.js
+++ b/plugin-src/client/styles.js
@@ -14,23 +14,22 @@ const CSS = String.raw`
 .dim-title { display: flex; align-items: center; justify-content: space-between; gap: 22px; margin: 0 0 26px; }
 .dim-title p { margin: 0; color: var(--dsw-alias-label-secondary, #646a73); font-size: 13px; line-height: 20px; white-space: nowrap; }
 .dim-channelCount { flex: none; padding: 6px 11px; border-radius: 999px; color: var(--dsw-alias-label-secondary, #646a73); background: var(--dsw-alias-fill-secondary, #f2f3f5); font-size: 11px; white-space: nowrap; }
-.dim-layout { display: grid; grid-template-columns: 188px 1px minmax(0, 1fr); gap: 26px; align-items: start; }
-.dim-rail { display: grid; gap: 12px; }
-.dim-channel { width: 100%; min-height: 76px; display: grid; grid-template-columns: 42px minmax(0, 1fr) 14px; align-items: center; gap: 12px; padding: 13px 12px; border: 1px solid transparent; border-radius: 16px; color: inherit; background: var(--dsw-alias-bg-layer-3, #fff); box-shadow: 0 5px 18px rgb(31 35 41 / 5%); font: inherit; text-align: left; cursor: pointer; transition: border-color .16s ease, background .16s ease, box-shadow .16s ease, transform .16s ease; }
-.dim-channel:hover { transform: translateY(-1px); border-color: color-mix(in srgb, var(--dim-blue) 25%, transparent); box-shadow: 0 8px 24px rgb(31 35 41 / 8%); }
-.dim-channel[aria-selected="true"] { border-color: color-mix(in srgb, var(--dim-blue) 52%, transparent); color: var(--dim-blue); background: var(--dim-blue-soft); box-shadow: 0 0 0 1px color-mix(in srgb, var(--dim-blue) 8%, transparent), 0 10px 26px rgb(51 112 255 / 10%); }
-.dim-channel:focus-visible { outline: 2px solid color-mix(in srgb, var(--dim-blue) 68%, white); outline-offset: 2px; }
-.dim-logo { width: 42px; height: 42px; display: grid; place-items: center; border-radius: 12px; box-shadow: 0 1px 4px rgb(31 35 41 / 8%); }
-.dim-logo svg { display: block; width: 27px; height: 27px; }
+.dim-layout { display: grid; grid-template-columns: 174px 1px minmax(0, 1fr); gap: 24px; align-items: start; }
+.dim-rail { max-height: 520px; display: grid; align-content: start; gap: 8px; overflow-y: auto; padding: 1px 4px 1px 1px; scrollbar-width: thin; scrollbar-color: var(--dsw-alias-line-border, #dfe1e5) transparent; }
+.dim-rail::-webkit-scrollbar { width: 4px; }
+.dim-rail::-webkit-scrollbar-thumb { border-radius: 99px; background: var(--dsw-alias-line-border, #dfe1e5); }
+.dim-channel { width: 100%; min-height: 48px; display: grid; grid-template-columns: 30px minmax(0, 1fr); align-items: center; gap: 10px; padding: 8px 12px; border: 1px solid var(--dsw-alias-line-border, #eef0f3); border-radius: 14px; color: inherit; background: var(--dsw-alias-bg-layer-3, #fff); box-shadow: 0 2px 8px rgb(31 35 41 / 3%); font: inherit; text-align: left; cursor: pointer; transition: border-color .16s ease, background .16s ease, box-shadow .16s ease; }
+.dim-channel:hover { border-color: color-mix(in srgb, var(--dim-blue) 25%, var(--dsw-alias-line-border, #eef0f3)); background: color-mix(in srgb, var(--dim-blue) 2%, var(--dsw-alias-bg-layer-3, #fff)); box-shadow: 0 5px 16px rgb(31 35 41 / 5%); }
+.dim-channel[aria-selected="true"] { border-color: color-mix(in srgb, var(--dim-blue) 43%, white); color: var(--dim-blue); background: color-mix(in srgb, var(--dim-blue) 9%, white); box-shadow: 0 3px 12px rgb(51 112 255 / 7%); }
+.dim-channel:focus-visible { outline: none; border-color: color-mix(in srgb, var(--dim-blue) 72%, white); box-shadow: 0 0 0 1px color-mix(in srgb, var(--dim-blue) 24%, transparent) inset, 0 3px 12px rgb(51 112 255 / 7%); }
+.dim-logo { width: 30px; height: 30px; display: grid; place-items: center; border-radius: 9px; box-shadow: 0 1px 3px rgb(31 35 41 / 7%); }
+.dim-logo svg { display: block; width: 20px; height: 20px; }
 .dim-logoWeixin { color: white; background: #07c160; }
-.dim-logoWeixin svg { width: 25px; height: 25px; }
+.dim-logoWeixin svg { width: 19px; height: 19px; }
 .dim-logoFeishu { background: white; border: 1px solid var(--dsw-alias-line-border, #e5e6eb); }
-.dim-logoFeishu svg { width: 30px; height: 30px; }
-.dim-channelCopy { min-width: 0; display: grid; gap: 2px; }
-.dim-channelCopy strong { overflow: hidden; color: inherit; font-size: 15px; line-height: 21px; font-weight: 680; text-overflow: ellipsis; white-space: nowrap; }
-.dim-channelCopy small { overflow: hidden; color: var(--dsw-alias-label-tertiary, #8f959e); font-size: 10px; line-height: 16px; text-overflow: ellipsis; white-space: nowrap; }
-.dim-chevron { color: var(--dsw-alias-label-tertiary, #8f959e); font-size: 22px; line-height: 1; transform: translateY(-1px); }
-.dim-channel[aria-selected="true"] .dim-chevron { color: var(--dim-blue); }
+.dim-logoFeishu svg { width: 22px; height: 22px; }
+.dim-channelCopy { min-width: 0; display: block; }
+.dim-channelCopy strong { overflow: hidden; color: inherit; font-size: 14px; line-height: 20px; font-weight: 680; text-overflow: ellipsis; white-space: nowrap; }
 .dim-divider { width: 1px; min-height: 520px; background: var(--dsw-alias-line-divider, #eef0f3); }
 .dim-panel { min-width: 0; }
 .dim-panel .bxf-page, .dim-panel .dxw-page { width: 100%; max-width: none; padding: 0 0 24px; }
@@ -41,7 +40,8 @@ const CSS = String.raw`
   .dim-layout { grid-template-columns: minmax(0, 1fr); gap: 18px; }
   .dim-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .dim-divider { display: none; }
-  .dim-channel { min-height: 68px; }
+  .dim-rail { max-height: none; overflow: visible; padding-right: 1px; }
+  .dim-channel { min-height: 48px; }
 }
 @media (max-width: 560px) {
   .dim-title { flex-direction: column; gap: 10px; }

--- a/test/client-ui.test.mjs
+++ b/test/client-ui.test.mjs
@@ -21,5 +21,6 @@ test('IM settings renders two logo channel tabs without enable switches', () => 
   assert.equal((markup.match(/role="tab"/g) ?? []).length, 2);
   assert.equal((markup.match(/aria-selected="true"/g) ?? []).length, 1);
   assert.doesNotMatch(markup, /role="switch"|type="checkbox"/);
+  assert.doesNotMatch(markup, /dim-chevron|扫码绑定<\/small>|扫码接入<\/small>/);
   assert.doesNotMatch(markup, />INSTANT MESSAGING<|>Channel<|>微信设置</);
 });


### PR DESCRIPTION
## What changed

- reduce IM channel rows to 48px with 30px logos and 8px spacing
- remove subtitles, chevrons, heavy shadows, and double focus rings
- keep selection to a single light-blue surface and border
- add an independently scrollable channel rail for future IM adapters

## Why

The original vertical tabs were too tall and visually heavier than the supplied reference. The compact rail now fits about nine channels in the current settings viewport before scrolling.

## Validation

- `npm run check` (17 tests, build, package artifact verification)
- live Harness browser validation for WeChat and Feishu channel switching
