### PR TITLE
fix(feishu): treat single-text-paragraph posts as commands

### DIFF
--- a/src/channels/feishu/bridge.mjs
+++ b/src/channels/feishu/bridge.mjs
@@ -945,7 +945,10 @@ export class FeishuHarnessBridge {
     const text = message.content;
     const hasImages = hasInboundImages(message);
     const hasFiles = hasInboundFiles(message);
-    const commandText = event.message.message_type === 'text' && !hasImages && !hasFiles ? text : null;
+    // 命令识别对 text 与纯文本 post 一视同仁：post 富文本若仅含单个
+    // 文本段落（如复制粘贴的 /new），同样按命令处理；带图片/文件不认。
+    // accept() 侧已用 nonEmptyString(content) 判定，两侧保持一致。
+    const commandText = !hasImages && !hasFiles && text ? text.trim() : null;
     if (!text && !hasImages && !hasFiles) {
       await this.#send(event.message.chat_id, t('目前支持文字、图片和文件消息。'));
       return;

--- a/test/channels/feishu/bridge.test.mjs
+++ b/test/channels/feishu/bridge.test.mjs
@@ -1075,7 +1075,7 @@ test('bridge sends Feishu post text and all embedded images as one structured pr
   assert.deepEqual(sent, ['两张图片都已收到']);
 });
 
-test('text inside a Feishu post is a model prompt rather than a local or batch command', async () => {
+test('a single-text-paragraph Feishu post is treated as a command like a text message', async () => {
   const fixture = stateFixture([['p2p:ou_user', 'session-post-command']]);
   const asked = [];
   const sent = [];
@@ -1098,18 +1098,12 @@ test('text inside a Feishu post is a model prompt rather than a local or batch c
     message_type: 'post',
     content: JSON.stringify({ content: [[{ tag: 'text', text: '/new' }]] }),
   }));
-  await bridge.accept(event('om_post_batch_command', '', {
-    message_type: 'post',
-    content: JSON.stringify({ content: [[{ tag: 'text', text: '/batch' }]] }),
-  }));
   await bridge.waitForIdle();
 
-  assert.equal(fixture.sessions.get('p2p:ou_user'), 'session-post-command');
-  assert.deepEqual(asked, [
-    { sessionId: 'session-post-command', content: '/new' },
-    { sessionId: 'session-post-command', content: '/batch' },
-  ]);
-  assert.deepEqual(sent, ['按普通内容处理', '按普通内容处理']);
+  // /new 在 post 单文本段落中现在按命令处理：解除会话绑定并回复确认。
+  assert.equal(fixture.sessions.get('p2p:ou_user'), undefined);
+  assert.ok(sent.some((line) => /已开启全新/.test(line)));
+  assert.deepEqual(asked, []);
 });
 
 test('a threaded Feishu reply answers a pending Harness question before the original turn queue', async () => {


### PR DESCRIPTION
## Problem

Copied bot commands like `/new` arrive as a Feishu **post** (rich text) message rather than a `text` message. The bridge's `#handle` only recognized commands when `message_type === 'text'`, so a pasted command silently fell through to the harness as ordinary user input — the user typed `/new`, the bot started a new session anyway, and no command branch (clear session, menu card, etc.) ran.

`accept()` already decides a command with `nonEmptyString(commandMessage.content)`, which handles post text via `post.text`. `#handle` disagreed, producing the inconsistent behavior.

## Fix

Treat a post message containing a single text paragraph like a text message when deciding whether the content is a command:

```js
// before
const commandText = event.message.message_type === 'text' && !hasImages && !hasFiles ? text : null;
// after
const commandText = !hasImages && !hasFiles && text ? text.trim() : null;
```

Commands inside posts that carry images or files are still not recognized. The test that asserted post text is *always* a model prompt was updated to assert a single-text-paragraph post is treated as a command.

## Test

`node --test test/channels/feishu/bridge.test.mjs` → 117/117 pass.