### PR TITLE
fix(dingtalk): stop AI Card from going blank at finish

### DIFF
--- a/src/channels/dingtalk/dingtalk-api.mjs
+++ b/src/channels/dingtalk/dingtalk-api.mjs
@@ -337,12 +337,22 @@ function cardMarkdown(text, target) {
 }
 
 function cardData(text, flowStatus, target) {
+  const markdown = cardMarkdown(text, target);
+  // The public AI Card template renders msgContent while streaming and
+  // switches to staticMsgContent once the streaming widget is torn down
+  // (flowStatus !== '2'). Leaving staticMsgContent empty, or leaving
+  // sys_full_json_obj.order pinned to msgContent after finalize, makes the
+  // finished/failed card render as a blank bubble even though the answer
+  // was streamed correctly moments earlier.
+  const streaming = flowStatus === '2';
   return {
     cardParamMap: {
       flowStatus,
-      msgContent: cardMarkdown(text, target),
-      staticMsgContent: '',
-      sys_full_json_obj: JSON.stringify({ order: ['msgContent'] }),
+      msgContent: markdown,
+      staticMsgContent: markdown,
+      sys_full_json_obj: JSON.stringify({
+        order: [streaming ? 'msgContent' : 'staticMsgContent'],
+      }),
       config: JSON.stringify({ autoLayout: true }),
     },
   };
@@ -922,13 +932,17 @@ export function createDingtalkApi({
 
       let delivered = false;
       try {
-        await cardRequest('v1.0/card/instances', {
+        // Deliver the thinking copy in the same request that first shows the
+        // card. Creating an empty instance and filling it after deliver (the
+        // previous three-request sequence) leaves a blank bubble visible in
+        // DingTalk for the time between deliver and the follow-up PUT, and
+        // leaves a permanently blank card if that PUT ever fails.
+        await cardRequest('v1.0/card/instances/createAndDeliver', {
           body: {
+            ...cardDeliverBody(cardInstanceId, normalizedTarget, appKey),
             cardTemplateId: DINGTALK_AI_CARD_TEMPLATE_ID,
             outTrackId: cardInstanceId,
-            cardData: {
-              cardParamMap: { config: JSON.stringify({ autoLayout: true }) },
-            },
+            cardData: cardData(content, '2', normalizedTarget),
             callbackType: 'STREAM',
             cardAtUserIds: normalizedTarget.atUserIds
               ? Object.keys(normalizedTarget.atUserIds)
@@ -938,37 +952,31 @@ export function createDingtalkApi({
           },
           headers,
           signal,
-          action: 'AI Card 创建',
-        });
-        await cardRequest('v1.0/card/instances/deliver', {
-          body: cardDeliverBody(cardInstanceId, normalizedTarget, appKey),
-          headers,
-          signal,
-          action: 'AI Card 投放',
+          action: 'AI Card 创建并投放',
         });
         delivered = true;
-        await cardRequest('v1.0/card/instances', {
-          method: 'PUT',
-          body: { outTrackId: cardInstanceId, cardData: cardData(content, '2', normalizedTarget) },
-          headers,
-          signal,
-          action: 'AI Card 启动',
-        });
-        await cardRequest('v1.0/card/streaming', {
-          method: 'PUT',
-          body: {
-            outTrackId: cardInstanceId,
-            guid: randomUUID(),
-            key: 'msgContent',
-            content: cardMarkdown(content, normalizedTarget).replace(/\n+$/, ''),
-            isFull: true,
-            isFinalize: false,
-            isError: false,
-          },
-          headers,
-          signal,
-          action: 'AI Card 启动',
-        });
+        try {
+          await cardRequest('v1.0/card/streaming', {
+            method: 'PUT',
+            body: {
+              outTrackId: cardInstanceId,
+              guid: randomUUID(),
+              key: 'msgContent',
+              content: cardMarkdown(content, normalizedTarget).replace(/\n+$/, ''),
+              isFull: true,
+              isFinalize: false,
+              isError: false,
+            },
+            headers,
+            signal,
+            action: 'AI Card 启动',
+          });
+        } catch (error) {
+          if (signal?.aborted) throw error;
+          // The card is already visible with the thinking copy from
+          // createAndDeliver above. Keep the instance so finishAiCard can
+          // still replace it in place instead of sending a second message.
+        }
       } catch (error) {
         if (delivered) {
           const cleanupSignal = AbortSignal.timeout(5_000);
@@ -1018,6 +1026,11 @@ export function createDingtalkApi({
       const token = await accessToken({ clientId, clientSecret, signal });
       const headers = { 'x-acs-dingtalk-access-token': token };
       const normalizedContent = cardMarkdown(content, target);
+      // Official close: overwrite msgContent with the full answer and set
+      // isFinalize=true in the same streaming request (DingTalk's "last
+      // frame"). A follow-up PUT /v1.0/card/instances after this — even one
+      // meant to set staticMsgContent — can blank the card once the
+      // streaming widget is torn down, so this must be the only request.
       await cardRequest('v1.0/card/streaming', {
         method: 'PUT',
         body: {
@@ -1033,28 +1046,7 @@ export function createDingtalkApi({
         signal,
         action: 'AI Card 完成',
       });
-      let completed = true;
-      const completionRequest = {
-        method: 'PUT',
-        body: {
-          outTrackId: instanceId,
-          cardData: cardData(content, '3', target),
-          cardUpdateOptions: { updateCardDataByKey: true },
-        },
-        headers,
-        signal,
-        action: 'AI Card 收口',
-      };
-      try {
-        await cardRequest('v1.0/card/instances', completionRequest);
-      } catch {
-        try {
-          await cardRequest('v1.0/card/instances', completionRequest);
-        } catch {
-          completed = false;
-        }
-      }
-      return { delivered: true, completed };
+      return { delivered: true, completed: true };
     },
 
     failAiCard: failCard,

--- a/src/channels/dingtalk/dingtalk-bridge.mjs
+++ b/src/channels/dingtalk/dingtalk-bridge.mjs
@@ -1329,12 +1329,19 @@ export class DingtalkHarnessBridge {
       const deliveryStartedAt = cardStartedAt ?? Date.now();
       try {
         streamed = cardStarted && await cardStream.finish(answerText);
-        if (streamed) {
+        if (streamed || cardStarted) {
+          // The card is already visible in the chat. Never send a second
+          // webhook text here: that would leave the original card behind
+          // (blank, or stuck on its last progress line) alongside a
+          // duplicate plain-text reply.
           textReceipt = createDeliveryReceipt({
             deliveryId: messageId,
             presentation: 'dingtalk-card',
             providerMessageIds: cardStream.providerMessageIds,
           });
+          if (!streamed) {
+            this.#logger.warn?.('[dsh-dingtalk] AI Card finish failed; keeping the delivered card');
+          }
         } else {
           textReceipt = createDeliveryReceipt({
             deliveryId: messageId,
@@ -1411,7 +1418,11 @@ export class DingtalkHarnessBridge {
           ? `${errorText}\n\n${batchFailureMessage}`
           : errorText;
         const streamed = cardStarted && await cardStream.finish(visibleError);
-        if (!streamed) await this.#send(sessionWebhook, visibleError, this.#atUsersFor(message));
+        // Same rule as the happy path: once the card is visible, never send
+        // a second webhook text alongside it, even if finish() failed.
+        if (!streamed && !cardStarted) {
+          await this.#send(sessionWebhook, visibleError, this.#atUsersFor(message));
+        }
       } catch {
         this.#logger.error?.('[dsh-dingtalk] failed to send the safe error reply');
       }

--- a/test/channels/dingtalk/dingtalk-api.test.mjs
+++ b/test/channels/dingtalk/dingtalk-api.test.mjs
@@ -816,7 +816,7 @@ test('session webhook validation accepts only HTTPS DingTalk hosts on the defaul
   }
 });
 
-test('AI Card replies create, deliver, stream full snapshots, and finalize on fixed endpoints', async () => {
+test('AI Card replies create-and-deliver, stream full snapshots, and finalize on fixed endpoints', async () => {
   const calls = [];
   const fetchImpl = async (url, options) => {
     calls.push({ url: url.toString(), options });
@@ -842,28 +842,30 @@ test('AI Card replies create, deliver, stream full snapshots, and finalize on fi
     token: options.headers['x-acs-dingtalk-access-token'],
     redirect: options.redirect,
   }));
+  // One request creates and delivers the card with the thinking copy already
+  // in place, so the chat never shows an empty shell. Every update after
+  // that is a plain streaming PUT, and finalize is the last streaming frame
+  // with no follow-up instances PUT that could blank the finished card.
   assert.deepEqual(cardCalls.map(({ method, path }) => ({ method, path })), [
-    { method: 'POST', path: '/v1.0/card/instances' },
-    { method: 'POST', path: '/v1.0/card/instances/deliver' },
-    { method: 'PUT', path: '/v1.0/card/instances' },
+    { method: 'POST', path: '/v1.0/card/instances/createAndDeliver' },
     { method: 'PUT', path: '/v1.0/card/streaming' },
     { method: 'PUT', path: '/v1.0/card/streaming' },
     { method: 'PUT', path: '/v1.0/card/streaming' },
-    { method: 'PUT', path: '/v1.0/card/instances' },
   ]);
   assert.ok(cardCalls.every(({ token, redirect }) => token === 'access-token' && redirect === 'error'));
   assert.equal(cardCalls[0].body.cardTemplateId, DINGTALK_AI_CARD_TEMPLATE_ID);
   assert.equal(cardCalls[0].body.outTrackId, card.cardInstanceId);
-  assert.equal(cardCalls[1].body.openSpaceId, 'dtv1.card//IM_ROBOT.staff-one');
-  assert.equal(cardCalls[1].body.imRobotOpenDeliverModel.robotCode, 'ding-client');
-  assert.equal(cardCalls[2].body.cardData.cardParamMap.flowStatus, '2');
-  assert.equal(cardCalls[3].body.content, '正在处理…');
-  assert.equal(cardCalls[4].body.content, '第一行<br>第二行');
-  assert.equal(cardCalls[4].body.isFull, true);
-  assert.equal(cardCalls[4].body.isFinalize, false);
-  assert.equal(cardCalls[5].body.content, '最终回答');
-  assert.equal(cardCalls[5].body.isFinalize, true);
-  assert.equal(cardCalls[6].body.cardData.cardParamMap.flowStatus, '3');
+  assert.equal(cardCalls[0].body.openSpaceId, 'dtv1.card//IM_ROBOT.staff-one');
+  assert.equal(cardCalls[0].body.imRobotOpenDeliverModel.robotCode, 'ding-client');
+  assert.equal(cardCalls[0].body.cardData.cardParamMap.flowStatus, '2');
+  assert.equal(cardCalls[0].body.cardData.cardParamMap.msgContent, '正在处理…');
+  assert.equal(cardCalls[0].body.cardData.cardParamMap.staticMsgContent, '正在处理…');
+  assert.equal(cardCalls[1].body.content, '正在处理…');
+  assert.equal(cardCalls[2].body.content, '第一行<br>第二行');
+  assert.equal(cardCalls[2].body.isFull, true);
+  assert.equal(cardCalls[2].body.isFinalize, false);
+  assert.equal(cardCalls[3].body.content, '最终回答');
+  assert.equal(cardCalls[3].body.isFinalize, true);
 });
 
 test('AI Cards keep native group mentions through every frame and leave private replies unchanged', async (t) => {
@@ -954,9 +956,15 @@ test('AI Cards keep native group mentions through every frame and leave private 
         assert.equal(Object.hasOwn(calls[0].body, 'cardAtUserIds'), false);
       }
       const deliveries = calls
-        .filter(({ path }) => path.endsWith('/instances/deliver'))
+        .filter(({ path }) => path.endsWith('/instances/createAndDeliver'))
         .map(({ body }) => body);
-      assert.deepEqual(deliveries, [{
+      assert.deepEqual(deliveries.map(({ outTrackId, userIdType, openSpaceId, imGroupOpenDeliverModel, imRobotOpenDeliverModel }) => ({
+        outTrackId,
+        userIdType,
+        openSpaceId,
+        ...(imGroupOpenDeliverModel ? { imGroupOpenDeliverModel } : {}),
+        ...(imRobotOpenDeliverModel ? { imRobotOpenDeliverModel } : {}),
+      })), [{
         outTrackId: card.cardInstanceId,
         userIdType: 1,
         ...scenario.delivery,
@@ -969,13 +977,18 @@ test('AI Cards keep native group mentions through every frame and leave private 
         { content: mention + '最终回答', isFinalize: true, isError: false },
         { content: mention + '处理失败', isFinalize: false, isError: true },
       ]);
+      // Only failAiCard still PUTs the instances endpoint (flowStatus '5');
+      // createAiCard now uses createAndDeliver, and finishAiCard's answer
+      // lives entirely in the last streaming frame above.
       const states = calls
         .filter(({ path, method }) => path.endsWith('/instances') && method === 'PUT')
         .map(({ body }) => body.cardData.cardParamMap);
-      assert.deepEqual(states.map(({ flowStatus, msgContent }) => ({ flowStatus, msgContent })), [
-        { flowStatus: '2', msgContent: mention + '正在处理…' },
-        { flowStatus: '3', msgContent: mention + '最终回答' },
-        { flowStatus: '5', msgContent: mention + '处理失败' },
+      assert.deepEqual(states.map(({ flowStatus, msgContent, staticMsgContent }) => ({
+        flowStatus,
+        msgContent,
+        staticMsgContent,
+      })), [
+        { flowStatus: '5', msgContent: mention + '处理失败', staticMsgContent: mention + '处理失败' },
       ]);
     });
   }
@@ -1062,18 +1075,14 @@ test('AI Card retries one QPS rejection after the configured backoff', async () 
   assert.deepEqual(waits, [1_000]);
 });
 
-test('AI Card cleanup marks failure while a completed final frame never falls back twice', async () => {
+test('AI Card finish failure propagates without a fallback instances PUT that could blank the card', async () => {
   const calls = [];
-  let rejectCompletedStatus = true;
   const fetchImpl = async (url, options) => {
     calls.push({ url: url.toString(), options });
     if (url.toString() === `${DINGTALK_API_BASE_URL}v1.0/oauth2/accessToken`) {
       return jsonResponse({ accessToken: 'access-token', expireIn: 7_200 });
     }
-    const body = JSON.parse(options.body);
-    if (rejectCompletedStatus
-      && new URL(url).pathname === '/v1.0/card/instances'
-      && body.cardData?.cardParamMap?.flowStatus === '3') {
+    if (new URL(url).pathname === '/v1.0/card/streaming') {
       return jsonResponse({}, { status: 500 });
     }
     return jsonResponse({});
@@ -1085,19 +1094,26 @@ test('AI Card cleanup marks failure while a completed final frame never falls ba
     cardInstanceId: 'card-one',
   };
 
-  assert.deepEqual(await api.finishAiCard({ ...request, text: '最终答案' }), {
-    delivered: true,
-    completed: false,
-  });
-  rejectCompletedStatus = false;
-  await api.failAiCard({ ...request, text: '处理失败' });
+  // finishAiCard now writes the answer only in the last streaming frame, so
+  // a failed streaming PUT must surface as a rejection instead of silently
+  // falling back to an instances PUT (the old two-request close, which is
+  // what left finished cards blank whenever the second PUT raced the
+  // template's teardown of the streaming widget).
+  await assert.rejects(api.finishAiCard({ ...request, text: '最终答案' }));
 
-  const bodies = calls
+  const cardBodies = calls
     .filter(({ url }) => new URL(url).pathname.startsWith('/v1.0/card/'))
     .map(({ options }) => JSON.parse(options.body));
-  assert.equal(bodies.some((body) => body.isFinalize === true && body.isError === false), true);
-  assert.equal(bodies.some((body) => body.isError === true), true);
-  assert.equal(bodies.some((body) => body.cardData?.cardParamMap?.flowStatus === '5'), true);
+  assert.equal(cardBodies.length, 1);
+  assert.equal(cardBodies[0].isFinalize, true);
+  assert.equal(cardBodies[0].content, '最终答案');
+
+  await api.failAiCard({ ...request, text: '处理失败' });
+  const afterFailure = calls
+    .filter(({ url }) => new URL(url).pathname.startsWith('/v1.0/card/'))
+    .map(({ options }) => JSON.parse(options.body));
+  assert.equal(afterFailure.some((body) => body.isError === true), true);
+  assert.equal(afterFailure.some((body) => body.cardData?.cardParamMap?.flowStatus === '5'), true);
 });
 
 test('AI Card creation cleanup preserves group mentions with an independent signal after abort', async () => {
@@ -1109,7 +1125,10 @@ test('AI Card creation cleanup preserves group mentions with an independent sign
     }
     const body = JSON.parse(options.body);
     bodies.push(body);
-    if (options.method === 'PUT' && body.cardData?.cardParamMap?.flowStatus === '2') {
+    // Let createAndDeliver succeed (the card is now live), then abort on the
+    // startup streaming PUT that follows it, so cleanup runs against an
+    // already-delivered card instead of short-circuiting before delivery.
+    if (new URL(url).pathname === '/v1.0/card/streaming' && body.isError !== true) {
       controller.abort(new DOMException('stopped', 'AbortError'));
       throw controller.signal.reason;
     }


### PR DESCRIPTION
## Problem

The DingTalk AI Card sometimes rendered blank, or showed the generic "卡片已结束，请查看后续消息。" close-out text instead of the model's real answer, even though the model had produced a normal reply.

This reproduced reliably in real usage and was root-caused to three independent bugs in the card lifecycle (a fourth factor — a DingTalk app permission gap on `PUT /v1.0/card/streaming` — was ruled out separately by confirming the failures persisted with the streaming permission fully granted and 200-ing on every request).

## Root causes and fixes

1. **Three-request card creation left an empty shell visible.** `createAiCard` called `POST /v1.0/card/instances` with an *empty* `cardData`, then `POST /v1.0/card/instances/deliver`, then a follow-up `PUT /v1.0/card/instances` to fill in the thinking text. The chat showed a blank card for the window between deliver and the fill PUT, and stayed blank forever if that PUT ever failed for any reason (network blip, transient 5xx, throttling). Fixed by using `POST /v1.0/card/instances/createAndDeliver` with the thinking text already populated in `cardData`, matching DingTalk's [documented create-and-deliver flow](https://open.dingtalk.com/document/development/create-and-deliver-cards) — the card is now never visible without content.

2. **`staticMsgContent` was always empty, and `sys_full_json_obj.order` never left `msgContent`.** The AI Card template renders `msgContent` while the streaming widget is active (`flowStatus: '2'`) but switches to `staticMsgContent` once that widget tears down (`flowStatus: '3'`/`'5'`). Because `staticMsgContent` was hardcoded to `''` and `order` was pinned to `['msgContent']` regardless of state, a finished or failed card rendered **blank** even though the answer had streamed correctly moments earlier. Fixed by mirroring `staticMsgContent` to the same markdown as `msgContent`, and switching `order` between `msgContent`/`staticMsgContent` based on whether the card is still streaming.

3. **`finishAiCard` raced its own finalize frame with a redundant second request.** It first sent the answer as the final streaming frame (`isFull: true, isFinalize: true`), then issued a *second*, independent `PUT /v1.0/card/instances` with the same content (retried once on failure). That second request could race the template's own streaming teardown and wipe out the answer the first request had just written — this was the most consistent source of the blank-after-finish symptom. Fixed by making `finishAiCard` issue only the one streaming request that DingTalk's docs describe as the finish step, matching the [typewriter-effect AI Card guide](https://open.dingtalk.com/document/development/typewriter-effect-streaming-ai-card).

4. **A duplicate plain-text fallback could appear next to an already-visible card.** In `dingtalk-bridge.mjs`, whenever `cardStream.finish()` returned `false` (e.g. a transient failure on the request above), the bridge sent a *second* reply via the plain webhook text API — even though the card had already been shown to the user. Users then saw a stale/blank card sitting next to a duplicate plain-text answer. Fixed so that once a card has started, the bridge never falls back to a second text message; it now logs the failure and leaves the delivered card as the single reply, in both the success path and the safe-error-reply path.

## Testing

Updated the existing `test/channels/dingtalk/dingtalk-api.test.mjs` assertions to match the corrected request sequence (one `createAndDeliver` instead of create+deliver+PUT, one finalize streaming frame instead of finalize-frame+instances-PUT-with-retry), and adjusted the abort-cleanup test to trigger after a successful `createAndDeliver` rather than on the old three-request creation path.

```
node --test test/channels/dingtalk/dingtalk-api.test.mjs      # 41/41 pass
node --test test/channels/dingtalk/dingtalk-bridge.test.mjs   # 70/70 pass
node --test test/channels/dingtalk/dingtalk-card-stream.test.mjs  # 5/5 pass
```

No behavior changes outside the DingTalk channel; no dependency or `package.json` changes.
